### PR TITLE
Add systemd service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SOURCE_FILES
         MpdClient.h
         TrackInfo.h)
 
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/mpd-discord.service
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 add_executable(mpd_discord_richpresence ${SOURCE_FILES})
 
 target_link_libraries(

--- a/mpd-discord.service
+++ b/mpd-discord.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Discord Rich Presence for MPD
+Requires=mpd.service
+After=mpd.service
+
+[Service]
+ExecStart=/usr/local/bin/mpd_discord_richpresence
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Adds a systemd service, to start this in the background on login. To use it you just copy it to ~/.config/systemd/user/ and run systemctl --user enable --now mpd-discord.service.
Sometimes doesnt work if discord is started after it.